### PR TITLE
sidekiq:activate causes error trying to cat a non-file. Echo instead.

### DIFF
--- a/commands
+++ b/commands
@@ -20,7 +20,7 @@ fi
 case "$1" in
 
   sidekiq:activate)
-    cat "ACTIVE" > "$DOKKU_ROOT/$APP/DEPLOY_SIDEKIQ"
+    echo "ACTIVE" > "$DOKKU_ROOT/$APP/DEPLOY_SIDEKIQ"
     echo "-----> Sidekiq automatic deployment activated for $2"
     ;;
 


### PR DESCRIPTION
Hey,

Love the plugin. Using it until the proposed dokku addons happens. Just had a slight issue with the activate command. It tries to cat a file that doesn't exist- 'ACTIVE'. I assumed the purpose was to echo 'ACTIVE' to that file so the post-deploy command sees it?

Cheers,
Maddi
