### PR TITLE
change docker repository namespace to dokku for docker 0.10 compatibility

### DIFF
--- a/post-deploy
+++ b/post-deploy
@@ -2,7 +2,7 @@
 set -eo pipefail
 APP="$1"; PORT="$2"
 
-IMAGE="app/$APP"
+IMAGE="dokku/$APP"
 
 if [[ -f "$DOKKU_ROOT/$APP/DEPLOY_SIDEKIQ" ]]; then
 


### PR DESCRIPTION
From this PR https://github.com/progrium/dokku/pull/535, dokku changed the `app` namespace to `dokku` since docker 0.10 required a minimum of 4 characters in the namespace.
