### PR TITLE
Remove unnecessary "/bin/cat" that hangs dokku

### DIFF
--- a/commands
+++ b/commands
@@ -46,4 +46,3 @@ EOF
     ;;
 
 esac
-cat


### PR DESCRIPTION
There are no arguments to /bin/cat therefore it waits for stdin and hangs infinitely.

Executing any dokku command (eg. dokku apps) hangs and you need to hit CTRL+C to get back to bash.
