### PR TITLE
Added plugin.toml

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "support for sidekiq via post-deploy hook"
+version = "0.1.0"
+[plugin.config]


### PR DESCRIPTION
Dokku requires a `plugin.tom` file that provides a description & version number for the plugin. See the docs:

http://dokku.viewdocs.io/dokku/development/plugin-creation/

This is what I created, and assumed a version of 0.1.0. Not sure if theres another version number to use, but its super easy to change (just modify the file).

Closes #10 
